### PR TITLE
Update mb_vsprintf method

### DIFF
--- a/src/Utils/Sprintf.php
+++ b/src/Utils/Sprintf.php
@@ -155,13 +155,20 @@ class Sprintf
         while ($format !== "") {
             // Split the format in two parts: $pre and $post by the first %-directive
             // We get also the matched groups
-            @list ($pre, $sign, $filler, $align, $size, $precision, $type, $post) =
-                preg_split(
-                    "!\%(\+?)('.|[0 ]|)(-?)([1-9][0-9]*|)(\.[1-9][0-9]*|)([%a-zA-Z])!u",
-                    $format,
-                    2,
-                    PREG_SPLIT_DELIM_CAPTURE
-                );
+            $split = preg_split(
+                "!\%(\+?)('.|[0 ]|)(-?)([1-9][0-9]*|)(\.[1-9][0-9]*|)([%a-zA-Z])!u",
+                $format,
+                2,
+                PREG_SPLIT_DELIM_CAPTURE
+            );
+            $pre = $split[0] ?? null;
+            $sign = $split[1] ?? null;
+            $filler = $split[2] ?? null;
+            $align = $split[3] ?? null;
+            $size = $split[4] ?? null;
+            $precision = $split[5] ?? null;
+            $type = $split[6] ?? null;
+            $post = $split[7] ?? null;
             
             $newformat .= mb_convert_encoding($pre, $encoding, 'UTF-8');
             


### PR DESCRIPTION
Phalcon 4.2+ debug returns an error when a simple warning occurs.
The list function returns a warning when the array created by the preg_split does not correspond to the number of parameters of the PHP list function.

On vanilla PHP, this does not cause any problem, because it assigns null to the unsetted parameters by default. Unfortunately, on a newer version of Phalcon, 4.2+, or Zephir, it catches the warning and returns an error, even when using @.

To avoid this error, simply assign the variables manually instead of using the PHP list function.

While this fix is not the prettiest or most advanced, it allows us to avoid having to modify the rest of the method which does not cause any problem.